### PR TITLE
Allow multiple font styles to be specified at once.

### DIFF
--- a/src/proto/semantic.rs
+++ b/src/proto/semantic.rs
@@ -46,6 +46,16 @@ pub enum FontStyleSetting {
     Inherit,
 }
 
+impl From<Option<bool>> for FontStyleSetting {
+    fn from(value: Option<bool>) -> Self {
+        match value {
+            Some(true) => FontStyleSetting::True,
+            Some(false) => FontStyleSetting::False,
+            None => FontStyleSetting::Inherit,
+        }
+    }
+}
+
 impl Serialize for Highlighting {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
I wanted to be able to specify bold _and_ italic in my theme, and couldn't see a way to do it out of the box, so I added a `Multi` variant to the `dsl::FontStyle` enum.

I wasn't sure if you would prefer using `Option<bool>` for each style option, or to reuse `proto::semantic::FontStyleSetting`, or create an equivalent of `FontStyleSetting` in `dsl`, so I just did the version which required the fewest changes (`Option<bool>`). Happy to change this.
